### PR TITLE
Support new boot_data format

### DIFF
--- a/src/get-slack-api-data.js
+++ b/src/get-slack-api-data.js
@@ -10,8 +10,8 @@ export default function getSlackApiData () {
       return;
     }
 
-    const apiTokenResult = /api_token\:\s\"(.*)\"/g.exec(script.innerText);
-    const versionUidResult = /version_uid\:\s\"(.*)\"/g.exec(script.innerText);
+    const apiTokenResult = /["]?api_token["]?\:\s*\"(.+?)\"/g.exec(script.innerText);
+    const versionUidResult = /["]?version_uid["]?\:\s*\"(.+?)\"/g.exec(script.innerText);
     
     if (apiTokenResult) {
       apiToken = apiTokenResult[1];


### PR DESCRIPTION
Seems the format for boot_data has changed maybe this morning, so NFET is unable to read the token and just passes in `undefined`, leading to `invalid_auth`.

This fixes the regexes for "parsing" `boot_data` to be more lenient. They should still work fine with the old format, too (so long as there are no quotes within `api_token` or `version_uid`).

As an aside, it looks like the new format is actual JSON, so it might be easier to switch to `JSON.parse()` should things change even more.

---

Fixes #11 
Fixes #12