### PR TITLE
Support new URL and rate limits

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
     "permissions": ["activeTab"],
     "content_scripts": [{
         "js": ["content.js"],
-        "matches": ["*://*.slack.com/*/emoji*"],
+        "matches": ["*://*.slack.com/*/emoji*","*://*.slack.com/emoji"],
         "run_at": "document_end"
     }],
     "icons": {

--- a/src/upload-emoji.js
+++ b/src/upload-emoji.js
@@ -9,8 +9,9 @@ const NO_OP = function () {};
 
 const superagentThrottle = new SuperagentThrottle({
   active: true,
-  concurrent: 5,
-  rate: Infinity
+  concurrent: 1,
+  rate: 1,
+  ratePer: 3000,
 });
 
 export default function uploadEmoji (file, callback = NO_OP) {


### PR DESCRIPTION
Looks like slack recently made some changes to their emoji page - they've changed the URL slightly, and it looks like they've also implemented some rate limiting on the `emoji.add` endpoint.  This PR adds the new URL format to the manifest.json, and sets a rate limit of 1 request every 5 seconds (rate limit based on trial and error).