### PR TITLE
Handle Slack rate limiting for large emoji sets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neutral-face-emoji-tools",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neutral-face-emoji-tools",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Tools that make life as a Slack emoji addict a little easier.",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "name": "Neutral Face Emoji Tools",
   "short_name": "Emoji Tools",
   "description": "Tools that make life as a Slack emoji addict a little easier.",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "permissions": [],
   "content_scripts": [{
     "js": ["content.js"],

--- a/src/upload-emoji.js
+++ b/src/upload-emoji.js
@@ -39,11 +39,11 @@ export default function uploadEmoji (file, callback = NO_OP) {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'
     }
-  }).catch((error) => {
-    callback(error, null);
   }).then((response) => {
     const error = _.get(response, 'data.error');
     callback(error, response);
+  }).catch((error) => {
+    callback(error, null);
   });
 
   return id;


### PR DESCRIPTION
- Enables handling HTTP 429 (rate limit) responses from Slack
- Fixes bug in `uploadEmoji` function caused by `.catch` before `.then` (both were getting executed)
- Adds sleep to `uploadFiles` function and changes to `for ... of` to switch to sequential processing and avoid sending all files to Slack at once
- Waits to verify no outstanding files need to be retried before exiting

Fixes Issue #9 