### PR TITLE
Add directory support to file upload picker

### DIFF
--- a/src/components/file-dropzone.svelte
+++ b/src/components/file-dropzone.svelte
@@ -80,5 +80,8 @@
   <input
     class="file-input"
     type="file"
+    webkitdirectory
+    directory
+    multiple
     on:change={handleFileChange} />
 </div>


### PR DESCRIPTION
Without this the only way to upload multiple files was drag/drop. I found that drag/drop consistently failed at ~1,000+ files, seemingly from the OS trying to add a nice visualization to it.

This code makes it so the file picker allows directory choices. I've tested it on a directory with 50,000 emojis and it seems to work well.