### PR TITLE
Automatically convert names to lower case

### DIFF
--- a/src/upload-emoji.js
+++ b/src/upload-emoji.js
@@ -20,7 +20,7 @@ export default function uploadEmoji (file, callback = NO_OP) {
   const timestamp = Date.now() / 1000;  
   const version = versionUid ? versionUid.substring(0, 8) : 'noversion';
   const id = uuid.v4();
-  const name = file.name.split('.')[0];
+  const name = file.name.split('.')[0].toLowerCase();
 
   const formData = new FormData();
   formData.append('name', name);


### PR DESCRIPTION
Slack seems to have issues showing emojis when they are uploaded as uppercase. Right now the tool will upload the uppercase named emoji to Slack correctly, but the emoji will show up as a black question mark when used in Slack.

This is also mentioned in the slack upload flow.

<img width="503" alt="Screenshot 2023-07-02 at 8 59 19 AM" src="https://github.com/Fauntleroy/neutral-face-emoji-tools/assets/1585623/3ccb530f-7b27-4172-85ca-a72489439097">
